### PR TITLE
ds actions

### DIFF
--- a/saltinator/src/actions/leaderboard.js
+++ b/saltinator/src/actions/leaderboard.js
@@ -1,0 +1,15 @@
+import {
+  LEADERBOARD_LOADING,
+  LEADERBOARD_SUCCESS,
+  LEADERBOARD_FAILURE
+} from "./types";
+
+export const fetchLeaderboard = () => async dispatch => {
+  dispatch({ type: LEADERBOARD_LOADING });
+  try {
+    const res = await axios.get("PRODUCTION_URL_HERE");
+    dispatch({ type: LEADERBOARD_SUCCESS, payload: res.data });
+  } catch (err) {
+    dispatch({ type: LEADERBOARD_FAILURE, payload: err });
+  }
+};

--- a/saltinator/src/actions/saving.js
+++ b/saltinator/src/actions/saving.js
@@ -6,6 +6,7 @@ export const saveComment = (userID, data) => async dispatch => {
   try {
     const payload = {
       user_id: data.userID,
+      Hacker_News_User: data.username,
       favorite_comments: data.comment,
       fav_salty_score: data.salt_score
     };

--- a/saltinator/src/actions/user.js
+++ b/saltinator/src/actions/user.js
@@ -1,0 +1,11 @@
+import { USER_LOADING, USER_SUCCESS, USER_FAILURE } from "./types";
+
+export const fetchUser = username => async dispatch => {
+  dispatch({ type: USER_LOADING });
+  try {
+    const res = await axios.get(`PRODUCTION_URL_HERE/${username}`);
+    dispatch({ type: USER_SUCCESS, payload: res.data });
+  } catch (err) {
+    dispatch({ type: USER_FAILURE, payload: err });
+  }
+};

--- a/saltinator/src/components/user/UserCard.js
+++ b/saltinator/src/components/user/UserCard.js
@@ -28,6 +28,7 @@ const UserCard = ({
     favorite_comments: comment,
     username,
     comment_id,
+    Hacker_News_User: hackerNewsUser,
     fav_salt_score: salt_score
   },
   saveComment,
@@ -40,15 +41,24 @@ const UserCard = ({
 
   return (
     <Card>
-      <br />"{comment}"<br />- {username}
       {pathname !== "/saved" ? (
-        <Button
-          onClick={() => saveComment(userID, { userID, comment, salt_score })}
-        >
-          Save
-        </Button>
+        <>
+          <br />"{comment}"<br />- {username}
+          <Button
+            onClick={() =>
+              saveComment(userID, { userID, comment, username, salt_score })
+            }
+          >
+            Save
+          </Button>
+        </>
       ) : (
-        <Button onClick={() => deleteComment(userID, comment_id)}>Delete</Button>
+        <>
+          <br />"{comment}"<br />- {hackerNewsUser}
+          <Button onClick={() => deleteComment(userID, comment_id)}>
+            Delete
+          </Button>
+        </>
       )}
     </Card>
   );

--- a/saltinator/src/reducers/rootReducer.js
+++ b/saltinator/src/reducers/rootReducer.js
@@ -19,6 +19,7 @@ export const rootReducer = (state = initialState, action) => {
     case types.SAVING_LOADING:
     case types.DELETE_LOADING:
     case types.LEADERBOARD_LOADING:
+    case types.USER_LOADING:
       return {
         ...state,
         isLoading: true
@@ -61,6 +62,20 @@ export const rootReducer = (state = initialState, action) => {
         isLoading: false,
         errors: null,
         leaderboard: payload
+      };
+    case types.USER_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        errors: null,
+        comments: payload
+      };
+    case types.USER_FAILURE:
+      return {
+        ...state,
+        isLoading: false,
+        errors: payload,
+        comments: []
       };
     case types.LEADERBOARD_FAILURE:
       return {

--- a/saltinator/src/reducers/rootReducer.js
+++ b/saltinator/src/reducers/rootReducer.js
@@ -13,13 +13,12 @@ const initialState = {
 export const rootReducer = (state = initialState, action) => {
   const { type, payload } = action;
 
-  console.log(action, state);
-
   switch (type) {
     case types.REGISTER_LOADING:
     case types.LOGIN_LOADING:
     case types.SAVING_LOADING:
     case types.DELETE_LOADING:
+    case types.LEADERBOARD_LOADING:
       return {
         ...state,
         isLoading: true
@@ -55,6 +54,20 @@ export const rootReducer = (state = initialState, action) => {
         isLoading: false,
         errors: null,
         savedComments: payload
+      };
+    case types.LEADERBOARD_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        errors: null,
+        leaderboard: payload
+      };
+    case types.LEADERBOARD_FAILURE:
+      return {
+        ...state,
+        isLoading: false,
+        errors: payload,
+        leaderboard: []
       };
     case types.REGISTER_FAILURE:
     case types.LOGIN_FAILURE:


### PR DESCRIPTION
added actions for fetching leaderboard and individual user's comments from the DS API (and corresponding changes to the reducer). right now there's just a dummy URL in there, will have to update to production url when available. also fixed the issue where saved comment cards were displaying the logged in user's name rather than the username of the commenter.